### PR TITLE
Remove 'Todo.create' examples from db/seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,9 +6,3 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-Todo.create!(title: 'grocery shopping', notes: 'pickles, eggs, red onion')
-Todo.create!(title: 'wash the car')
-Todo.create!(title: 'register kids for school', notes: 'Register Kira for Ruby Junior High and Caleb for Rails High School')
-Todo.create!(title: 'check engine light', notes: 'The check engine light is on in the Tacoma')
-Todo.create!(title: 'dog groomers', notes: 'Take Pinky and Redford to the groomers on Wednesday the 23rd')
-


### PR DESCRIPTION
these cause rake db:setup to fail
