### PR TITLE
Integration test

### DIFF
--- a/test/controllers/vouchers_controller_test.rb
+++ b/test/controllers/vouchers_controller_test.rb
@@ -48,7 +48,7 @@ class VouchersControllerTest < ActionController::TestCase
   end
   
   test "should get help" do
-    get vouchers_help_url
+    get :help
     assert_response :success
   end  
   

--- a/test/integration/release_funds_test.rb
+++ b/test/integration/release_funds_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class ReleaseFundsTest < ActionDispatch::IntegrationTest
+  test "should be able to release vouchers" do
+    # code to create a voucher
+    # assert voucher was created
+    # assert voucher is not released
+
+    # http post that calls the voucher release action
+    # assert success on previous
+
+    # http get on voucher status
+    # assert marked as released via HTTP
+    # assert marked as released via Model
+    
+    assert false # fill in
+  end
+
+  test "should not be able to re-release vouchers" do
+    # code to create a voucher
+    # assert voucher was created
+    # assert voucher is not released
+
+    # http post that calls the voucher release action
+    # assert success on previous
+
+    # http get on voucher status
+    # save as variable
+
+    # http post that calls the voucher release action again
+    # assert error on previous (should not be able to re-release)
+
+    # http get on voucher status
+    # assert voucher is unchanged
+    
+    assert false # fill in
+  end
+end


### PR DESCRIPTION
This fixes some confusion in the use of `ActionController:Testcase` (aka controller test) vs `ActionDispatch::IntegrationTest` (aka integration test)

basically, all tests in tests/controllers inheriting from Controller Test should use the ControllerTest style of

```
get :action_name
```

whereas all tests in tests/integration should use the IntegrationTest style of

```
get action_url
```

It also includes a sample IntegrationTest that shows how an integration test differs from a ControllerTest. IntegrationTests are used to test the function of the app from the end user perspective, ControllerTests just test the methods of the controller. In many cases (smaller apps) there is not much difference between the two.

When in doubt, use IntegrationTests rather than controller tests. Use `rails generate integration_test` to create the template.
