### PR TITLE
Move VoucherAccount select from view to controller

### DIFF
--- a/app/controllers/vouchers_controller.rb
+++ b/app/controllers/vouchers_controller.rb
@@ -79,6 +79,7 @@ class VouchersController < ApplicationController
 
   # GET /vouchers/1/edit
   def edit
+    @accounts = VoucherAccount.all
   end
 
   # POST /vouchers

--- a/app/views/vouchers/_form.html.erb
+++ b/app/views/vouchers/_form.html.erb
@@ -29,7 +29,7 @@
   </div>
   <div class="field">
     <%= f.label :voucher_account_id %><br>
-    <%= f.select :voucher_account_id, options_for_select(VoucherAccount.all.map{|s|[s.name, s.id]}, include_blank: true) %>
+    <%= f.select :voucher_account_id, options_for_select(@accounts.map{|s|[s.name, s.id]}, include_blank: true) %>
   </div>
   <div class="field">
     <%= f.label :amount %><br>


### PR DESCRIPTION
Rather than running any select queries in the view (`VoucherAccount.all`), we run it in the controller and reference it in the view.

This gives us the flexibility to later on use program logic to select VoucherAccount. For instance, if the list of VoucherAccounts depends on the logged in user, that logic can be done in the controller as

```
@accounts = current_user.voucher_accounts
```

without affecting the view.

This might be useful if, for example, one user is only authorized to release vouchers for certain accounts, or each user has a different list of defined voucher accounts.

In general, don't perform selects in the view to increase flexibility in the code.
